### PR TITLE
fix the accessibility regressions introduced by dark mode

### DIFF
--- a/index.html
+++ b/index.html
@@ -131,7 +131,7 @@ show_header: true
     <span>Ben Foxall</span>
 
     <a href="https://github.com/benfoxall/" class="📣" aria-label="Ben on Github">
-      <img src="./images/gh.png" alt=""  width="16" height="16" />
+      <img class="gh" src="./images/gh.png" alt=""  width="16" height="16" />
       <span class="sr-only">Ben on GitHub</span>
     </a>
     <a href="https://twitter.com/benjaminbenben" class="📣" aria-label="Ben on Twitter">
@@ -144,7 +144,7 @@ show_header: true
     <img src="images/RyanAlsoWithAHat-small.jpg" alt="Ryan Brooks, also wearing a hat"> 
     <span>Ryan Brooks</span>
     <a href="https://github.com/spikeheap/" class="📣" aria-label="Ryan on Github">
-      <img src="./images/gh.png" alt="" />
+      <img class="gh" src="./images/gh.png" alt="" />
       <span class="sr-only">Ryan on GitHub</span>
     </a>
     <a href="https://twitter.com/spikeheap" class="📣" aria-label="Ryan on Twitter">

--- a/stylez.css
+++ b/stylez.css
@@ -2,7 +2,8 @@
   --background: #fff;
   --background-light: #E6E7E8;
   --foreground: #000;
-  --link: red;
+  --link: blue;
+  --filter: invert(0);
 }
 
 @media (prefers-color-scheme: dark) {
@@ -11,6 +12,7 @@
     --background-light: #171717;
     --foreground: #fff;
     --link: aquamarine;
+    --filter: invert(1);
   } 
 }
 
@@ -158,6 +160,11 @@ a {
   margin-right: .5em;
   transition: transform .2s;
 }
+
+.gh {
+  filter: var(--filter);
+}
+
 .📣:hover img {
   transform: scale(1.4) rotate(4deg)
 }


### PR DESCRIPTION
dark mode disappeared the github icons, plus the red links in regular mode
put us back in a11y troubles, so sorting both of those issues.

![dark a11y dragoon](https://user-images.githubusercontent.com/5070516/79024984-6c381f80-7b7c-11ea-8c94-a90c9dfbebfc.jpg)
