### PR TITLE
make the links bigger as tap targets

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -51,6 +51,7 @@
     <a href="/"> / </a>
     <a href="/code-of-conduct"> Conduct </a>
     <a href="/about"> About </a>
+    <a href="/previous-hacks">Previous hacks</a>
     <a href="/podcast"> Podcast </a>
   </nav>
 

--- a/assets/style.css
+++ b/assets/style.css
@@ -52,6 +52,11 @@ ol {
   padding: 0;
 }
 
+.past-events li {
+  font-size: 2.5rem;
+  margin: 0.5em;
+}
+
 ol li:before {
   content: "– ";
 }

--- a/index.html
+++ b/index.html
@@ -40,20 +40,6 @@ end: 2020-06-27T16:30Z
     </p>
   </div>
 
-  <div>
-    <h3>Past events</h3>
-    <ol>
-      <li>
-        <a href="/hacks/03">May</a>
-      </li>
-      <li>
-        <a href="/hacks/02">April</a>
-      </li>
-      <li>
-        <a href="/hacks/01">March</a>
-      </li>
-    </ol>
-  </div>
 </section>
 
 

--- a/previous-hacks.md
+++ b/previous-hacks.md
@@ -1,0 +1,21 @@
+---
+layout: default
+---
+
+# Previous hacks
+
+This started out as an idea for just one random day, but we've since decided to keep doing it on the last saturday of every month.
+
+Here are links to writeups of our previous hack days!
+
+<ol class="past-events">
+  <li>
+    <a href="/hacks/03">May</a>
+  </li>
+  <li>
+    <a href="/hacks/02">April</a>
+  </li>
+  <li>
+    <a href="/hacks/01">March</a>
+  </li>
+</ol>


### PR DESCRIPTION
lighthouse was complaining that our tap targets were too small, and this was
affecting SEO (the horror!).

![tap targets too small](https://user-images.githubusercontent.com/5070516/85393330-b9554c00-b544-11ea-9dd9-1cd3d9e742b7.png)


This commit makes those links bigger, and also sets the flex display to
a columnar one, since we (presumably) will eventually have months like
'september' in there, and that won't look great on mobile if flex direction is
`row`.