### PR TITLE
update styles for super small screens

### DIFF
--- a/assets/style.css
+++ b/assets/style.css
@@ -114,10 +114,12 @@ ol li:before {
   max-width: 35em;
   margin: 3em auto;
   display: flex;
+  flex-wrap: wrap;
   font-family: "Space Mono", serif;
 }
 .🗺 a {
   margin-right: 1em;
+  margin-bottom: 1em;
   color: var(--link);
   background: var(--background-light);
   padding: 0.5em;


### PR DESCRIPTION
the top bar started out with only a few things, but as we've added items to it, it's become wider than the screen on small devices.

This commit adds the delicious flex-wrap and added margin so it looks tasty.

current site:
![current site on small screens](https://user-images.githubusercontent.com/5070516/93873249-51d8a500-fcc9-11ea-98c4-ec83b2b87b93.png)

small screen wrap with this commit:
![screen with this commit](https://user-images.githubusercontent.com/5070516/93873274-5ac97680-fcc9-11ea-8713-fcda11e8cbb9.png)
