### PR TITLE
🗓 November

### DIFF
--- a/_hacks/07.md
+++ b/_hacks/07.md
@@ -1,0 +1,6 @@
+---
+hack_number: 7
+date: 2020-09-26
+---
+We had such a good time we forgot to write up September's hack 🤪. 
+

--- a/_hacks/08.md
+++ b/_hacks/08.md
@@ -1,0 +1,5 @@
+---
+hack_number: 8
+date: 2020-10-31
+---
+We had such a good time we forgot to write up October's hack too 🤪. 

--- a/_hacks/09_code_retreat.md
+++ b/_hacks/09_code_retreat.md
@@ -12,7 +12,6 @@ We used Game of Life for each session:
 - Session 1: All together, solving Game of Life on paper & experimenting with TDD.
 - Session 2: In pairs doing TDD ping-pong. The constraint was "subversive developer". One person writes the best tests, and the other tries to write the worst code that passes those tests.
 - Session 3: In pairs doing driver/navigator ("strong style"). The constraint was to have no mutable state.
-- Session 4:In pairs doing driver/navigator, no conditionals.
+- Session 4: In pairs doing driver/navigator, no conditionals.
 - Session 5: Mob programming with one driver. The constraint was to have no variables in any of our code (including tests).
-
 

--- a/_hacks/09_code_retreat.md
+++ b/_hacks/09_code_retreat.md
@@ -1,0 +1,18 @@
+---
+hack_number: 09
+date: 2020-10-31
+event_name: Code Retreat
+---
+### This was a Code Retreat 🥳
+
+We met up and did a few katas, pair-programming and doing test-driven-development. The day was really fun, and provoked some interesting discussions around approaches and what felt nice. We also leaned heavily in Sveta's knowledge of array streams in Java 🙌.
+
+We used Game of Life for each session:
+
+- Session 1: All together, solving Game of Life on paper & experimenting with TDD.
+- Session 2: In pairs doing TDD ping-pong. The constraint was "subversive developer". One person writes the best tests, and the other tries to write the worst code that passes those tests.
+- Session 3: In pairs doing driver/navigator ("strong style"). The constraint was to have no mutable state.
+- Session 4:In pairs doing driver/navigator, no conditionals.
+- Session 5: Mob programming with one driver. The constraint was to have no variables in any of our code (including tests).
+
+

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -50,7 +50,6 @@
     <a href="/about"> About </a>
     <a href="/previous-hacks"> Previous Hacks </a>
     <a href="/podcast"> Podcast </a>
-    <a href="/code-retreat"> Code Retreat </a>
   </nav>
 
   <script>

--- a/index.html
+++ b/index.html
@@ -2,8 +2,8 @@
 layout: default
 show_header: true
 
-start: 2020-10-31T09:30Z
-end: 2020-10-31T16:30Z
+start: 2020-11-28T09:30Z
+end: 2020-11-28T16:30Z
 ---
 
 <p class="lead">

--- a/previous-hacks.md
+++ b/previous-hacks.md
@@ -12,7 +12,12 @@ Here are links to write-ups of our previous hack days!
   {% assign sorted_hacks = site.hacks | sort:"date" | reverse %}
   {% for hack in sorted_hacks %}
     <li>
-      <a href="{{ hack.url }}">{{hack.date | date: '%B %Y' }}</a>
+      <a href="{{ hack.url }}">
+        {{hack.date | date: '%B %Y' }}
+        {% if hack.event_name %}
+        - {{hack.event_name}}
+        {% endif %}
+      </a>
     </li>
   {% endfor %}
 </ol>


### PR DESCRIPTION
The last hack of 2020 is almost here, before we take a little break over Christmas 🎄.

This PR:

- Adds the November hack date for the homepage
- Adds placeholder/excuse write-ups for September/October
- Adds a write-up for the Code Retreat last Saturday. To make this read better in the log, I also introduced an optional `event_name` to the hack metadata, so we can call out one-off things
- Removes the Code Retreat navbar item, because it's happened now :)
