### PR TITLE
upgrade jekyll image to one that uses bundler v2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM jekyll/jekyll:3.5
+FROM jekyll/jekyll:3.8
 
 COPY ./Gemfile /srv/jekyll
 


### PR DESCRIPTION
the current jekyll image won't run with the version of bundler used for our lockfile, so need to update it so our local DX renames sweet like candy!