### PR TITLE
add repository for jekyll config to build site correctly

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -12,6 +12,7 @@ description: >- # this means to ignore newlines until "baseurl:"
 baseurl: "/" # the subpath of your site, e.g. /blog
 url: "https://remotehack.space" # the base hostname & protocol for your site, e.g. http://example.com
 github_username: remotehack
+repository: remotehack/remotehack.github.io
 # Build settings
 plugins:
   - jekyll-redirect-from


### PR DESCRIPTION
the site isn't building correctly on branch deploys, and complaining about this missing:

```
9:27:19 PM: $ jekyll build
9:27:20 PM: Configuration file: /opt/build/repo/_config.yml
9:27:21 PM:             Source: /opt/build/repo
9:27:21 PM:        Destination: /opt/build/repo/_site
9:27:21 PM:  Incremental build: disabled. Enable with --incremental
9:27:21 PM:       Generating...
9:27:21 PM:   Liquid Exception: No repo name found. Specify using PAGES_REPO_NWO environment variables, 'repository' in your configuration, or set up an 'origin' git remote pointing to your github.com repository. in /_layouts/default.html
9:27:21 PM:              ERROR: YOUR SITE COULD NOT BE BUILT:
9:27:21 PM:                     ------------------------------------
9:27:21 PM:                     No repo name found. Specify using PAGES_REPO_NWO environment variables, 'repository' in your configuration, or set up an 'origin' git remote pointing to your github.com repository.
```

...this oughta fix it