### PR TITLE
add two crons to update for start/end of BST

### DIFF
--- a/.github/workflows/set_for_end_of_british_summertime.yml
+++ b/.github/workflows/set_for_end_of_british_summertime.yml
@@ -1,0 +1,20 @@
+on:
+    schedule:
+        # fire this at 8PM every year on October 31 (the day the clocks fall back at 2AM)
+        - cron: "0 20 31 10 *"
+
+jobs:
+    update:
+        runs-on: ubuntu-latest
+        name: Turn off BST time adjustment
+        steps:
+            - uses: actions/checkout@v3
+            - name: Update to reflect end of British Summer time
+              run: |
+                  sed -i 's/T08:30Z/T09:30Z/g' pages/index.html
+
+                  git config --global user.email "date-bot@remotehack.com"
+                  git config --global user.name "date-bot"
+                  git add .
+                  git commit -m "update start time to reflect end of British Summer time"
+                  git push origin main

--- a/.github/workflows/set_for_start_of_british_summertime.yml
+++ b/.github/workflows/set_for_start_of_british_summertime.yml
@@ -1,0 +1,20 @@
+on:
+    schedule:
+        # fire this at 8PM every year on March 31 (the day the clocks spring forward at 1AM)
+        - cron: "0 20 31 3 *"
+
+jobs:
+    update:
+        runs-on: ubuntu-latest
+        name: Turn on BST adjustment
+        steps:
+            - uses: actions/checkout@v3
+            - name: Update to reflect start of British Summer time
+              run: |
+                  sed -i 's/T09:30Z/T08:30Z/g' pages/index.html
+
+                  git config --global user.email "date-bot@remotehack.com"
+                  git config --global user.name "date-bot"
+                  git add .
+                  git commit -m "update start time to reflect start of British Summer time"
+                  git push origin main


### PR DESCRIPTION
I got tired of needing to remind myself when to update this so the start time on the landing page is correct. I also couldn't figure out the liquid templating to make this conditional, so if somebody else wants to raise that PR, I'll very happily review/approve...cause that would be much cleaner.